### PR TITLE
Update Terraform config according to detected traffic

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -24,11 +24,9 @@ resource "aws_iam_policy" "s3_access_policy" {
         Effect   = "Allow"
         Action   = [
           "s3:ListBucket",
-          "s3:GetObject"
         ]
         Resource = [
-          "arn:aws:s3:::*",
-          "arn:aws:s3:::*/*"
+          "arn:aws:s3:::otterize-logo"
         ]
       }
     ]


### PR DESCRIPTION
This pull request updates the Terraform resources for services according to their actual traffic, as seen starting 1 day prior to this PR opening, so that they are able to access their destinations. If this traffic is intentional, approve the pull request. If the traffic is erroneous, fix the problem so that the traffic no longer occurs, and the pull request will automatically update.

[View the traffic graphically on Otterize Cloud](https://app.otterize.com/access-graph)

The following resources had their Terraform config updated due to new traffic, seen starting at Sun Mar 16 12:10:44 UTC 2025:

[s3_access_policy](https://app.otterize.com/access-graph?org=org_yxumtfkeri&serviceIds=svc_udrnp2l4bv&since=2024-09-10T10%3A13%3A16Z)